### PR TITLE
Added catch of parse exception in minify that was failing silently

### DIFF
--- a/tasks/html_minify.js
+++ b/tasks/html_minify.js
@@ -40,7 +40,12 @@ module.exports = function (grunt) {
                     // Read file source.
                     return grunt.file.read(filepath, {encoding: options.charset});
                 }).join('');
-            var content = minify(src,options);
+            var content;
+            try{
+                content = minify(src,options);
+            } catch (err){
+                grunt.fail.fatal('Error minifying file: '+f.src+'. '+err);
+            }
             // Handle options.
             // Write the destination file.
 


### PR DESCRIPTION
Hi, we had an example that was failing silently on a bad html. The html is using nunjucks as template engine and we had the following code that wasn't unable to minify but the grunt task ends as success:

``` html
<td {% if (text | length ) >= 64 %} height="60" {% else %} height="30" {% endif %}>
```

Because of the > inside the if the parser believes that it's the close of the td tag resulting on an html parse exception when it finds the other >.

This commit turns the task in a failure notifying the error
